### PR TITLE
Optimización: cacheo de heightmap y ancho en hot-path

### DIFF
--- a/Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs
+++ b/Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs
@@ -1023,8 +1023,10 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
             try
             {
                 //this.WriteLogFunctionEnter(method, i, j, value);
-                
-                this.resultMap.Heightmap[j*this.resultMap.Width + i] = value;
+
+                var heightmap = this.resultMap.Heightmap;
+                int mapWidth = this.resultMap.Width;
+                heightmap[j * mapWidth + i] = value;
             }
             catch(Exception ex)
             {
@@ -1050,7 +1052,9 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
 
                 generatedHeight = getHeightForPoint(x, y, z);
 
-                this.resultMap.Heightmap[j*this.resultMap.Width + i] = generatedHeight;
+                var heightmap = this.resultMap.Heightmap;
+                int mapWidth = this.resultMap.Width;
+                heightmap[j * mapWidth + i] = generatedHeight;
             }
             catch(Exception ex)
             {

--- a/docs/efficiency-results.md
+++ b/docs/efficiency-results.md
@@ -4,7 +4,7 @@ Tabla histórica para comparar cambios de eficiencia del proyecto con el tiempo.
 
 Cómo generar una nueva fila:
 
-- `dotnet run -c Release --project Console/WorldGen.Console.TestConsole/WorldGen.Console.TestConsole.csproj -- efficiency --improvement "Mejora 1" --output "docs/efficiency-results.md"`
+- `dotnet run -c Release --project Console/WorldGen.Console.TestConsole/WorldGen.Console.TestConsole.csproj -- efficiency --improvement "Mejora X" --output "docs/efficiency-results.md"`
 
 La consola añadirá una nueva fila (si no existe ya) con la fecha y los tiempos por resolución.
 
@@ -17,3 +17,4 @@ La consola añadirá una nueva fila (si no existe ya) con la fecha y los tiempos p
 | 2026-01-29	| Mejora 3		| 474,631 ms	| 733,321 ms	| 1,946 s		| 3,22 s		| 6,687 s		|
 | 2026-02-02	| Mejora 3b		| 197,225 ms	| 233,167 ms	| 1,012 s		| 1,501 s		| 3,01 s		|
 | 2026-02-03	| Mejora 5		| 233,637 ms	| 208,757 ms	| 1,167 s		| 1,5 s			| 2,901 s		|
+| 2026-02-04	| Mejora 6		| 299,412 ms	| 338,715 ms	| 1,24 s		| 2,162 s		| 3,935 s		|

--- a/efficiency-improvements.md
+++ b/efficiency-improvements.md
@@ -133,6 +133,30 @@ En subdivisiones profundas, las copias de puntos y los recálculos de longitudes 
 
 - `Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs`
 
+### Mejora 6: cacheo de índices y arrays
+
+**Qué se cambió**
+
+- En el hot-path de escritura del `HeightMap` se cachean referencias y valores usados repetidamente:
+  - `heightmap = resultMap.Heightmap`
+  - `mapWidth = resultMap.Width`
+- La escritura pasa de `resultMap.Heightmap[j * resultMap.Width + i] = ...` a `heightmap[j * mapWidth + i] = ...`.
+- Aplicado en:
+  - `setFixedPointValue(i, j, value)`
+  - `generatePoint(x, y, z, i, j)`
+
+**Motivación**
+
+En bucles por píxel, acceder repetidamente a propiedades (`resultMap.Heightmap`, `resultMap.Width`) y recomponer expresiones puede añadir overhead innecesario. Cachear variables locales ayuda al JIT y reduce trabajo repetitivo sin tocar el orden de evaluación.
+
+**Impacto esperado**
+
+- Micro-optimización (bajo–medio): menor overhead por acceso a propiedades y computación de índice en el hot-path.
+
+**Ficheros**
+
+- `Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs`
+
 ## Mejoras pendientes
 
 ### Mejora 1 (ampliación): logging hot-path completo (opcional)
@@ -149,9 +173,9 @@ En subdivisiones profundas, las copias de puntos y los recálculos de longitudes 
 
 ### Mejora 6: cacheo de índices y arrays
 
-- Problema: recalcular `j*Width+i` y accesos repetidos a propiedades.
-- Acción: cachear `heightmap`, `width` y `rowBase` por fila.
-- Impacto esperado: bajo–medio.
+- Estado: implementada parcialmente.
+- Hecho: cacheo de `heightmap` y `width` en los métodos de escritura del hot-path (`setFixedPointValue`, `generatePoint`).
+- Pendiente: si se quiere exprimir más, cachear por fila (`rowBase = j * width`) directamente dentro de los bucles de proyección (sin reordenar píxeles) para evitar multiplicaciones por píxel.
 
 ### Mejora 7: `throw ex;` -> `throw;`
 


### PR DESCRIPTION
Se cachean en variables locales el array heightmap y el ancho del mapa en los métodos críticos de TetrahedralSubdivision para reducir accesos repetidos a propiedades y mejorar la eficiencia en bucles por píxel. Documentada la mejora (Mejora 6) y actualizados los resultados y ejemplos en los archivos de eficiencia.