### PR TITLE
Mejoras: throw; y early-return en doLatitudeIcecaps

### DIFF
--- a/Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs
+++ b/Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs
@@ -215,7 +215,7 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
             catch(Exception ex)
             {
                 this.WriteLogError(method, ex);
-                throw ex;
+                throw;
             }
             finally
             {
@@ -239,7 +239,7 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
             catch(Exception ex)
             {
                 this.WriteLogError(method, ex);
-                throw ex;
+                throw;
             }
             finally
             {
@@ -363,7 +363,7 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
             catch(Exception ex)
             {
                 this.WriteLogError(method, ex);
-                throw ex;
+                throw;
             }
             finally
             {
@@ -1363,20 +1363,22 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
                 //this.WriteLogFunctionEnter(method, alt, y);
 
                 result = alt;
-                if(IsDoLatitudeIcecapsSet)
+                if (!IsDoLatitudeIcecapsSet)
                 {
-                    yRaised = y * y;
-                    yRaised *= yRaised;
-                    yRaised *= yRaised;
-                    if(result <= 0 &&
-                        yRaised + alt >= 1.0 - 0.02)
-                    {
-                        result = double.MaxValue;
-                    }
-                    else
-                    {
-                        result += 0.1 * yRaised;
-                    }
+                    return result;
+                }
+
+                yRaised = y * y;
+                yRaised *= yRaised;
+                yRaised *= yRaised;
+                if(result <= 0 &&
+                    yRaised + alt >= 1.0 - 0.02)
+                {
+                    result = double.MaxValue;
+                }
+                else
+                {
+                    result += 0.1 * yRaised;
                 }
 
                 if (result >= 0.1)
@@ -1387,7 +1389,7 @@ namespace WorldGen.Algorithm.TetrahedralSubdivision
             catch(Exception ex)
             {
                 this.WriteLogError(MethodBase.GetCurrentMethod(), ex);
-                throw ex;
+                throw;
             }
             finally
             {

--- a/docs/efficiency-results.md
+++ b/docs/efficiency-results.md
@@ -18,3 +18,4 @@ La consola añadirá una nueva fila (si no existe ya) con la fecha y los tiempos p
 | 2026-02-02	| Mejora 3b		| 197,225 ms	| 233,167 ms	| 1,012 s		| 1,501 s		| 3,01 s		|
 | 2026-02-03	| Mejora 5		| 233,637 ms	| 208,757 ms	| 1,167 s		| 1,5 s			| 2,901 s		|
 | 2026-02-04	| Mejora 6		| 299,412 ms	| 338,715 ms	| 1,24 s		| 2,162 s		| 3,935 s		|
+| 2026-02-05	| Mejora 7+8	| 289,42 ms		| 298,793 ms	| 1,283 s		| 2,068 s		| 3,931 s		|

--- a/efficiency-improvements.md
+++ b/efficiency-improvements.md
@@ -43,6 +43,43 @@ Aunque gran parte del logging por píxel ya estaba comentado, quedaban llamadas a
 
 - `Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs`
 
+### Mejora 7: `throw ex;` -> `throw;`
+
+**Qué se cambió**
+
+- En `catch (Exception ex)` se reemplazaron los `throw ex;` por `throw;`.
+
+**Motivación**
+
+`throw ex;` reinicia el stack trace y dificulta el diagnóstico. `throw;` preserva el stack trace original y evita trabajo extra del runtime al reconstruir la excepción.
+
+**Impacto esperado**
+
+- Rendimiento: bajo (solo camino excepcional).
+- Diagnóstico: alto (stack trace correcto).
+
+**Ficheros**
+
+- `Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs`
+
+### Mejora 8: `doLatitudeIcecaps` early-return
+
+**Qué se cambió**
+
+- En `doLatitudeIcecaps(alt, y)` se añadió un retorno temprano cuando `IsDoLatitudeIcecapsSet == false`, evitando calcular `yRaised` y lógica asociada.
+
+**Motivación**
+
+Cuando no están activados los icecaps por latitud, la función puede devolver el valor base sin realizar trabajo adicional.
+
+**Impacto esperado**
+
+- Bajo–medio si `doLatitudeIcecaps` se invoca frecuentemente con la feature desactivada.
+
+**Ficheros**
+
+- `Core/Algorithm/WorldGen.Algorithm.TetrahedralSubdivision/TetrahedralSubdivision.cs`
+
 ### Mejora 2: evitar `new Point3D` por píxel
 
 **Qué se cambió**
@@ -171,23 +208,13 @@ En bucles por píxel, acceder repetidamente a propiedades (`resultMap.Heightmap`,
 - Acción: convertir a iterativo preservando exactamente el orden de mutaciones/decisiones.
 - Impacto esperado: medio.
 
-### Mejora 6: cacheo de índices y arrays
-
-- Estado: implementada parcialmente.
-- Hecho: cacheo de `heightmap` y `width` en los métodos de escritura del hot-path (`setFixedPointValue`, `generatePoint`).
-- Pendiente: si se quiere exprimir más, cachear por fila (`rowBase = j * width`) directamente dentro de los bucles de proyección (sin reordenar píxeles) para evitar multiplicaciones por píxel.
-
 ### Mejora 7: `throw ex;` -> `throw;`
 
-- Problema: `throw ex;` pierde stack trace.
-- Acción: usar `throw;`.
-- Impacto esperado: rendimiento bajo, diagnóstico alto.
+- Estado: implementada.
 
 ### Mejora 8: `doLatitudeIcecaps` early-return
 
-- Problema: trabajo extra cuando `IsDoLatitudeIcecapsSet == false`.
-- Acción: retorno temprano.
-- Impacto esperado: bajo–medio.
+- Estado: implementada.
 
 ## Roadmap sugerido
 


### PR DESCRIPTION
- Reemplazado `throw ex;` por `throw;` para preservar el stack trace original en excepciones.
- Añadido retorno temprano en `doLatitudeIcecaps` cuando la feature está desactivada, evitando cálculos innecesarios.
- Actualizados los documentos de eficiencia con explicación y resultados de las mejoras aplicadas.